### PR TITLE
Added `projectName` for `conf` package

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const DEFAULT = require('./config')
  * server({cache: '/Users/mac/mbtiles', port: 5000, verbose: true})
  */
 module.exports = function (options = {}) {
-  const config = new Conf({projectName: "MBTiles Server"})
+  const config = new Conf({ projectName: 'MBTiles Server' })
   config.set('PROTOCOL', options.protocol || DEFAULT.PROTOCOL)
   config.set('PORT', options.port || DEFAULT.PORT)
   config.set('DOMAIN', options.domain || DEFAULT.DOMAIN)
@@ -49,7 +49,7 @@ module.exports = function (options = {}) {
      * @returns {Promise<Object>} port
      */
     start (options = {}) {
-      let protocol = options.protocol || DEFAULT.PROTOCOL
+      const protocol = options.protocol || DEFAULT.PROTOCOL
       const port = options.port || DEFAULT.PORT
       const domain = options.domain || DEFAULT.DOMAIN
       const cache = options.cache || DEFAULT.CACHE

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const DEFAULT = require('./config')
  * server({cache: '/Users/mac/mbtiles', port: 5000, verbose: true})
  */
 module.exports = function (options = {}) {
-  const config = new Conf()
+  const config = new Conf({projectName: "MBTiles Server"})
   config.set('PROTOCOL', options.protocol || DEFAULT.PROTOCOL)
   config.set('PORT', options.port || DEFAULT.PORT)
   config.set('DOMAIN', options.domain || DEFAULT.DOMAIN)

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 const { getFiles } = require('../utils')
 
 // Configurations
-const config = new Conf({projectName: "MBTiles Server"})
+const config = new Conf({ projectName: 'MBTiles Server' })
 
 /**
  * Route for API

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 const { getFiles } = require('../utils')
 
 // Configurations
-const config = new Conf()
+const config = new Conf({projectName: "MBTiles Server"})
 
 /**
  * Route for API

--- a/routes/mbtiles.js
+++ b/routes/mbtiles.js
@@ -6,7 +6,7 @@ const MBTiles = require('mbtiles-offline')
 const { mbtilesNotFound } = require('./utils')
 
 // Configurations
-const config = new Conf()
+const config = new Conf({projectName: "MBTiles Server"})
 const CACHE = config.get('CACHE')
 
 /**

--- a/routes/mbtiles.js
+++ b/routes/mbtiles.js
@@ -6,7 +6,7 @@ const MBTiles = require('mbtiles-offline')
 const { mbtilesNotFound } = require('./utils')
 
 // Configurations
-const config = new Conf({projectName: "MBTiles Server"})
+const config = new Conf({ projectName: 'MBTiles Server' })
 const CACHE = config.get('CACHE')
 
 /**

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -9,7 +9,7 @@ const tiletype = require('@mapbox/tiletype')
 const { mbtilesNotFound, invalidTile, tileNotFound, invalidVersion, invalidService, getQuery, invalidQuery } = require('./utils')
 
 // Configurations
-const config = new Conf()
+const config = new Conf({projectName: "MBTiles Server"})
 const PORT = config.get('PORT')
 const CACHE = config.get('CACHE')
 const DOMAIN = config.get('DOMAIN')

--- a/routes/wmts.js
+++ b/routes/wmts.js
@@ -9,7 +9,7 @@ const tiletype = require('@mapbox/tiletype')
 const { mbtilesNotFound, invalidTile, tileNotFound, invalidVersion, invalidService, getQuery, invalidQuery } = require('./utils')
 
 // Configurations
-const config = new Conf({projectName: "MBTiles Server"})
+const config = new Conf({ projectName: 'MBTiles Server' })
 const PORT = config.get('PORT')
 const CACHE = config.get('CACHE')
 const DOMAIN = config.get('DOMAIN')

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ const cache = path.join(__dirname, 'test', 'fixtures')
 
 test('utils', t => {
   const files = getFiles(cache)
-  t.deepEqual(files, [ 'canada_zoom_0-3', 'fiji_zoom_0-4', 'world_zoom_0-2' ])
+  t.deepEqual(files, ['canada_zoom_0-3', 'fiji_zoom_0-4', 'world_zoom_0-2'])
   t.end()
 })
 


### PR DESCRIPTION
I'm running into the error:

```
/usr/lib/node_modules/mbtiles-server/node_modules/conf/index.js:58
				throw new Error('Project name could not be inferred. Please specify the `projectName` option.');
				^

Error: Project name could not be inferred. Please specify the `projectName` option.
    at new Conf (/usr/lib/node_modules/mbtiles-server/node_modules/conf/index.js:58:11)
    at module.exports (/usr/lib/node_modules/mbtiles-server/index.js:25:18)
    at Object.<anonymous> (/usr/lib/node_modules/mbtiles-server/bin/mbtiles-server.js:50:12)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
```

In an installation I'm running, and adding the `projectName` seems to fix it.